### PR TITLE
Automatically check diffs with terraform-docs on GitHub Actions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -60,3 +60,4 @@ jobs:
           chmod +x terraform-docs
 
       - name: Check terraform-docs diffs
+        run: git --no-pager diff

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,3 +45,16 @@ jobs:
 
       - name: Terraform fmt
         run: terraform fmt -diff -check -recursive .
+
+  terraform-docs:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download terraform-docs
+        run: |
+          curl -O https://github.com/terraform-docs/terraform-docs/releases/download/v0.12.1/terraform-docs-v0.12.1-darwin-amd64.tar.gz
+          tar -zxvf terraform-docs-v0.12.1-darwin-amd64.tar.gz
+          ls

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -64,4 +64,8 @@ jobs:
         run: ./tmp/terraform-docs .
 
       - name: Check terraform-docs diffs
-        run: git --no-pager diff
+        run: |
+          if [[ $(git --no-pager diff) ]] ; then
+            echo "You need to run `terraform-docs .` before commit."
+            git --no-pager diff
+            exit 1

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -55,9 +55,9 @@ jobs:
 
       - name: Download terraform-docs
         run: |
-          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.12.1/terraform-docs-v0.12.1-$(uname)-amd64.tar.gz
-          tar -xzf terraform-docs.tar.gz
-          chmod +x terraform-docs
+          curl -Lo /tmp/terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.12.1/terraform-docs-v0.12.1-$(uname)-amd64.tar.gz
+          tar -xzf /tmp/terraform-docs.tar.gz
+          chmod +x /tmp/terraform-docs
 
       - name: Check terraform-docs diffs
         run: git --no-pager diff

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -55,6 +55,6 @@ jobs:
 
       - name: Download terraform-docs
         run: |
-          curl -O https://github.com/terraform-docs/terraform-docs/releases/download/v0.12.1/terraform-docs-v0.12.1-darwin-amd64.tar.gz
-          tar -zxvf terraform-docs-v0.12.1-darwin-amd64.tar.gz
-          ls
+          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.12.1/terraform-docs-v0.12.1-$(uname)-amd64.tar.gz
+          tar -xzf terraform-docs.tar.gz
+          chmod +x terraform-docs

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -55,9 +55,13 @@ jobs:
 
       - name: Download terraform-docs
         run: |
-          curl -Lo /tmp/terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.12.1/terraform-docs-v0.12.1-$(uname)-amd64.tar.gz
-          tar -xzf /tmp/terraform-docs.tar.gz
-          chmod +x /tmp/terraform-docs
+          mkdir tmp
+          curl -Lo tmp/terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.12.1/terraform-docs-v0.12.1-$(uname)-amd64.tar.gz
+          tar -xzf tmp/terraform-docs.tar.gz -C tmp
+          chmod +x tmp/terraform-docs
+
+      - name: Run terraform-docs
+        run: ./tmp/terraform-docs .
 
       - name: Check terraform-docs diffs
         run: git --no-pager diff

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -69,3 +69,4 @@ jobs:
             echo "You need to run `terraform-docs .` before commit."
             git --no-pager diff
             exit 1
+          fi

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -58,3 +58,5 @@ jobs:
           curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.12.1/terraform-docs-v0.12.1-$(uname)-amd64.tar.gz
           tar -xzf terraform-docs.tar.gz
           chmod +x terraform-docs
+
+      - name: Check terraform-docs diffs

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ terraform.*
 
 terraform-docs
 terraform-docs-*
+
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ __pycache__
 .terraform
 .terraform.*
 terraform.*
+
 terraform-docs
+terraform-docs-*

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "project_id" {
 
 variable "project_number" {
   type        = string
-  description = "Google Cloud Platform project number"
+  description = "Google Cloud Platform project number."
 }
 
 variable "log_topic" {

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "project_id" {
 
 variable "project_number" {
   type        = string
-  description = "Google Cloud Platform project number."
+  description = "Google Cloud Platform project number"
 }
 
 variable "log_topic" {


### PR DESCRIPTION
## What

- Apply `terraform-docs .` on GitHub Actions and check diffs
  - It prevent us not to forget `terraform-docs` before commit

## Related issues

- close #23 