### PR TITLE
Remove unused variables in example

### DIFF
--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -2,13 +2,3 @@ variable "project_id" {
   type    = string
   default = "<your-project-id>"
 }
-
-variable "project_number" {
-  type    = string
-  default = "<your-project-number>"
-}
-
-variable "cloud_run_image" {
-  type    = string
-  default = "<your-cloud-run-image>"
-}


### PR DESCRIPTION
## What

Remove variables `project_number` and `cloud_run_image`. These variables are no longer used.
