### PR TITLE
Fix variable name: project_id ==> project

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This section is automatically generated with [terraform-docs](https://github.com
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| project\_id | Google Cloud Platform project ID. | `string` | n/a | yes |
+| project | Google Cloud Platform project ID. | `string` | n/a | yes |
 | log\_topic | Pub/Sub topic name for log sink. | `string` | `"ai-platform-log"` | no |
 | notification\_topic | Pub/Sub topic name for notification message. | `string` | `"ai-platform-notification"` | no |
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,22 +1,22 @@
 provider "google-beta" {
-  project = var.project_id
+  project = var.project
 }
 
 module "ai_platform_notification" {
-  source     = "../"
-  project_id = var.project_id
+  source  = "../"
+  project = var.project
 }
 
 resource "google_pubsub_subscription" "ai_platform_notification" {
   name                 = "ai-platform-notification-test"
-  project              = var.project_id
+  project              = var.project
   topic                = module.ai_platform_notification.notification_topic.id
   ack_deadline_seconds = 60
 }
 
 resource "google_pubsub_subscription" "ai_platform_log" {
   name                 = "ai-platform-log-test"
-  project              = var.project_id
+  project              = var.project
   topic                = module.ai_platform_notification.log_topic.id
   ack_deadline_seconds = 60
 }

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -1,4 +1,4 @@
-variable "project_id" {
+variable "project" {
   type    = string
   default = "<your-project-id>"
 }

--- a/main.tf
+++ b/main.tf
@@ -7,9 +7,9 @@ data "archive_file" "functions" {
 
 # Cloud Storage bucket to save Cloud Functions' source code.
 resource "google_storage_bucket" "functions" {
-  name          = "${var.project_id}-ai-platform-notification"
+  name          = "${var.project}-ai-platform-notification"
   location      = "us-central1"
-  project       = var.project_id
+  project       = var.project
   storage_class = "REGIONAL"
 }
 
@@ -27,7 +27,7 @@ resource "google_cloudfunctions_function" "function" {
   source_archive_bucket = google_storage_bucket.functions.name
   source_archive_object = google_storage_bucket_object.functions.name
   entry_point           = "main"
-  project               = var.project_id
+  project               = var.project
   region                = "us-central1"
   event_trigger {
     event_type = "google.pubsub.topic.publish"
@@ -41,19 +41,19 @@ resource "google_cloudfunctions_function" "function" {
 # Pub/Sub topic to receive AI Platform logs.
 resource "google_pubsub_topic" "ai_platform_log" {
   name    = "ai-platform-log"
-  project = var.project_id
+  project = var.project
 }
 
 # Pub/Sub topic to receive push notifications from Cloud Run.
 resource "google_pubsub_topic" "ai_platform_notification" {
   name    = "ai-platform-notification"
-  project = var.project_id
+  project = var.project
 }
 
 # Log sink to send AI Platform logs to Stackdriver Logging.
 resource "google_logging_project_sink" "ai_platform_log" {
   name                   = "ai-platform-log"
-  project                = var.project_id
+  project                = var.project
   destination            = "pubsub.googleapis.com/${google_pubsub_topic.ai_platform_log.id}"
   filter                 = "resource.type=ml_job AND resource.labels.task_name=service"
   unique_writer_identity = true

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-variable "project_id" {
+variable "project" {
   type        = string
   description = "Google Cloud Platform project ID."
 }


### PR DESCRIPTION
## What

Fix the module's variable name: `project_id` ==> `project`

## Why

Variable name `project` is typically used for Terraform resource:
https://registry.terraform.io/providers/hashicorp/google/latest/docs